### PR TITLE
Correctly rename the mps plugin to json-bulk

### DIFF
--- a/mps-plugin/.mps/modules.xml
+++ b/mps-plugin/.mps/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="MPSProject">
     <projectModules>
-      <modulePath path="$PROJECT_DIR$/solutions/org.modelix.mps.rest.model.access.plugin.build/org.modelix.mps.rest.model.access.plugin.build.msd" folder="" />
-      <modulePath path="$PROJECT_DIR$/solutions/org.modelix.mps.rest.model.acess.plugin/org.modelix.mps.rest.model.acess.plugin.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/org.modelix.mps.json.bulk.model.access.plugin.build/org.modelix.mps.json.bulk.model.access.plugin.build.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/org.modelix.mps.json.bulk.model.access.plugin/org.modelix.mps.json.bulk.model.access.plugin.msd" folder="" />
     </projectModules>
   </component>
 </project>

--- a/mps-plugin/build.gradle.kts
+++ b/mps-plugin/build.gradle.kts
@@ -46,7 +46,7 @@ val copyServer = tasks.create<Sync>("copyServer"){
             "${ra.name}.${ra.extension}"
         }
     }
-    into("$projectDir/solutions/org.modelix.mps.rest.model.acess.plugin/lib")
+    into("$projectDir/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib")
 }
 
 ext["itemis.mps.gradle.ant.defaultScriptClasspath"] = buildDependencies.fileCollection { true }

--- a/mps-plugin/build.xml
+++ b/mps-plugin/build.xml
@@ -36,7 +36,7 @@
     <mkdir dir="${build.layout}/mps.plugin/META-INF" />
     <echoxml file="${build.layout}/mps.plugin/META-INF/plugin.xml">
       <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
-        <id>org.modelix.mps.rest.model.acess.mpsplugin</id>
+        <id>org.modelix.mps.json.bulk.model.access.mpsplugin</id>
         <name>mps.plugin</name>
         <version>1.0</version>
         <depends>jetbrains.mps.core</depends>
@@ -49,10 +49,10 @@
     </echoxml>
     <mkdir dir="${build.layout}/mps.plugin/languages" />
     <mkdir dir="${build.layout}/mps.plugin/languages/mps.plugin" />
-    <mkdir dir="${build.tmp}/default/org.modelix.mps.rest.model.acess.plugin.jar" />
-    <mkdir dir="${build.tmp}/default/org.modelix.mps.rest.model.acess.plugin.jar/META-INF" />
-    <echoxml file="${build.tmp}/default/org.modelix.mps.rest.model.acess.plugin.jar/META-INF/module.xml">
-      <module namespace="org.modelix.mps.rest.model.acess.plugin" type="solution" uuid="3257c0a0-131a-49aa-b7eb-4ec72ed06b33">
+    <mkdir dir="${build.tmp}/default/org.modelix.mps.json.bulk.model.access.plugin.jar" />
+    <mkdir dir="${build.tmp}/default/org.modelix.mps.json.bulk.model.access.plugin.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/org.modelix.mps.json.bulk.model.access.plugin.jar/META-INF/module.xml">
+      <module namespace="org.modelix.mps.json.bulk.model.access.plugin" type="solution" uuid="3257c0a0-131a-49aa-b7eb-4ec72ed06b33">
         <dependencies>
           <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="rt" />
           <module ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" kind="rt" />
@@ -89,30 +89,30 @@
         <classpath>
           <entry path="." />
         </classpath>
-        <sources jar="org.modelix.mps.rest.model.acess.plugin-src.jar" descriptor="org.modelix.mps.rest.model.acess.plugin.msd" />
+        <sources jar="org.modelix.mps.json.bulk.model.access.plugin-src.jar" descriptor="org.modelix.mps.json.bulk.model.access.plugin.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.layout}/mps.plugin/languages/mps.plugin/org.modelix.mps.rest.model.acess.plugin.jar" duplicate="preserve">
-      <fileset dir="${build.tmp}/java/out/org.modelix.mps.rest.model.acess.plugin" />
-      <fileset dir="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
-      <fileset dir="${build.tmp}/default/org.modelix.mps.rest.model.acess.plugin.jar" />
+    <jar destfile="${build.layout}/mps.plugin/languages/mps.plugin/org.modelix.mps.json.bulk.model.access.plugin.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/org.modelix.mps.json.bulk.model.access.plugin" />
+      <fileset dir="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/org.modelix.mps.json.bulk.model.access.plugin.jar" />
     </jar>
-    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-org.modelix.mps.rest.model.acess.plugin-models">
-      <fileset dir="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-org.modelix.mps.json.bulk.model.access.plugin-models">
+      <fileset dir="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.layout}/mps.plugin/languages/mps.plugin/org.modelix.mps.rest.model.acess.plugin-src.jar" duplicate="preserve">
-      <fileset dir="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/source_gen">
+    <jar destfile="${build.layout}/mps.plugin/languages/mps.plugin/org.modelix.mps.json.bulk.model.access.plugin-src.jar" duplicate="preserve">
+      <fileset dir="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
         <exclude name="**/checkpoints" />
         <exclude name="**/*.mps" />
       </fileset>
-      <zipfileset file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/org.modelix.mps.rest.model.acess.plugin.msd" prefix="module" />
-      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-org.modelix.mps.rest.model.acess.plugin-models" prefix="module/models" />
+      <zipfileset file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/org.modelix.mps.json.bulk.model.access.plugin.msd" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-org.modelix.mps.json.bulk.model.access.plugin-models" prefix="module/models" />
     </jar>
     <mkdir dir="${build.layout}/mps.plugin/lib" />
     <copy todir="${build.layout}/mps.plugin/lib">
-      <fileset dir="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/lib" />
+      <fileset dir="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib" />
     </copy>
     <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mpsBootstrapCore.version.major=${mpsBootstrapCore.version.major}${line.separator}mpsBootstrapCore.version.minor=${mpsBootstrapCore.version.minor}${line.separator}mpsBootstrapCore.version.bugfixNr=${mpsBootstrapCore.version.bugfixNr}${line.separator}mpsBootstrapCore.version.eap=${mpsBootstrapCore.version.eap}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}</echo>
   </target>
@@ -128,7 +128,7 @@
     <delete dir="${build.layout}" />
   </target>
   
-  <target name="compileJava" depends="java.compile.org.modelix.mps.rest.model.acess.plugin" />
+  <target name="compileJava" depends="java.compile.org.modelix.mps.json.bulk.model.access.plugin" />
   
   <target name="processResources" />
   
@@ -232,7 +232,7 @@
       <library file="${artifacts.mps}/languages/workbench/jetbrains.mps.lang.plugin.standalone.jar" />
       <library file="${artifacts.mps}/languages/xml/jetbrains.mps.core.xml.jar" />
       <chunk>
-        <module file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/org.modelix.mps.rest.model.acess.plugin.msd" />
+        <module file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/org.modelix.mps.json.bulk.model.access.plugin.msd" />
       </chunk>
       <jvmargs>
         <arg value="-ea" />
@@ -250,13 +250,13 @@
   
   <target name="makeDependents" />
   
-  <target name="java.compile.org.modelix.mps.rest.model.acess.plugin" depends="fetchDependencies">
-    <mkdir dir="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/source_gen" />
-    <mkdir dir="${build.tmp}/java/out/org.modelix.mps.rest.model.acess.plugin" />
-    <javac destdir="${build.tmp}/java/out/org.modelix.mps.rest.model.acess.plugin" fork="true" encoding="utf8" includeantruntime="false" debug="true">
+  <target name="java.compile.org.modelix.mps.json.bulk.model.access.plugin" depends="fetchDependencies">
+    <mkdir dir="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/org.modelix.mps.json.bulk.model.access.plugin" />
+    <javac destdir="${build.tmp}/java/out/org.modelix.mps.json.bulk.model.access.plugin" fork="true" encoding="utf8" includeantruntime="false" debug="true">
       <compilerarg value="-Xlint:none" />
       <src>
-        <path location="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/source_gen" />
+        <path location="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/source_gen" />
       </src>
       <classpath>
         <fileset file="${artifacts.mps}/lib/mps-core.jar" />
@@ -285,15 +285,15 @@
         <fileset file="${artifacts.mps}/lib/mps-textgen.jar" />
         <fileset file="${artifacts.mps}/lib/mps-icons.jar" />
         <fileset file="${artifacts.mps}/lib/mps-workbench.jar" />
-        <fileset file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/lib/annotations.jar" />
-        <fileset file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/lib/kotlin-stdlib-common.jar" />
-        <fileset file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/lib/kotlin-stdlib-jdk7.jar" />
-        <fileset file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/lib/kotlin-stdlib-jdk8.jar" />
-        <fileset file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/lib/kotlin-stdlib.jar" />
-        <fileset file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/lib/kotlinx-serialization-core-jvm.jar" />
-        <fileset file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/lib/kotlinx-serialization-json-jvm.jar" />
-        <fileset file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/lib/model-api-jvm.jar" />
-        <fileset file="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/lib/model-server.jar" />
+        <fileset file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib/annotations.jar" />
+        <fileset file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib/kotlin-stdlib-common.jar" />
+        <fileset file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib/kotlin-stdlib-jdk7.jar" />
+        <fileset file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib/kotlin-stdlib-jdk8.jar" />
+        <fileset file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib/kotlin-stdlib.jar" />
+        <fileset file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib/kotlinx-serialization-core-jvm.jar" />
+        <fileset file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib/kotlinx-serialization-json-jvm.jar" />
+        <fileset file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib/model-api-jvm.jar" />
+        <fileset file="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/lib/model-server.jar" />
         <fileset file="${artifacts.mps}/lib/annotations.jar" />
         <fileset dir="${artifacts.mps}/lib" includes="*.jar" />
         <fileset file="${artifacts.mps}/lib/log4j.jar" />
@@ -307,6 +307,6 @@
   </target>
   
   <target name="cleanSources">
-    <delete dir="${basedir}/solutions/org.modelix.mps.rest.model.acess.plugin/source_gen" />
+    <delete dir="${basedir}/solutions/org.modelix.mps.json.bulk.model.access.plugin/source_gen" />
   </target>
 </project>

--- a/mps-plugin/solutions/org.modelix.mps.json.bulk.model.access.plugin.build/models/org.modelix.mps.json.bulk.model.access.mps.plugin.build.mps
+++ b/mps-plugin/solutions/org.modelix.mps.json.bulk.model.access.plugin.build/models/org.modelix.mps.json.bulk.model.access.mps.plugin.build.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:fc49d5a3-c459-4089-b0b6-a40402d62ee5(org.modelix.mps-rest-model-acess.mps-plugin.build)">
+<model ref="r:fc49d5a3-c459-4089-b0b6-a40402d62ee5(org.modelix.mps.json.bulk.model.access.mps.plugin.build)">
   <persistence version="9" />
   <languages>
     <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
@@ -138,7 +138,7 @@
     </node>
     <node concept="1l3spV" id="6KKKEIn3ulV" role="1l3spN">
       <node concept="m$_wl" id="6KKKEIn3ulZ" role="39821P">
-        <ref role="m_rDy" node="6KKKEIn3ulI" resolve="org.modelix.mps.rest.model.acess.mpsplugin" />
+        <ref role="m_rDy" node="6KKKEIn3ulI" resolve="org.modelix.mps.json.bulk.model.access.mpsplugin" />
         <node concept="pUk6x" id="6KKKEIn3um0" role="pUk7w" />
         <node concept="398223" id="6KKKEInk1kh" role="39821P">
           <node concept="3_J27D" id="6KKKEInk1ki" role="Nbhlr">
@@ -151,7 +151,7 @@
               <node concept="2Ry0Ak" id="6KKKEInk1mC" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
                 <node concept="2Ry0Ak" id="1oqSG6gS27U" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
                   <node concept="2Ry0Ak" id="1oqSG6gS28y" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
                   </node>
@@ -163,7 +163,7 @@
       </node>
     </node>
     <node concept="m$_wf" id="6KKKEIn3ulI" role="3989C9">
-      <property role="m$_wk" value="org.modelix.mps.rest.model.acess.mpsplugin" />
+      <property role="m$_wk" value="org.modelix.mps.json.bulk.model.access.mpsplugin" />
       <node concept="3_J27D" id="6KKKEIn3ulJ" role="m$_yQ">
         <node concept="3Mxwew" id="6KKKEIn3ulK" role="3MwsjC">
           <property role="3MwjfP" value="mps.plugin" />
@@ -192,15 +192,15 @@
     <node concept="2G$12M" id="6KKKEIn3ulH" role="3989C9">
       <property role="TrG5h" value="mps.plugin" />
       <node concept="1E1JtA" id="6KKKEIn3ulG" role="2G$12L">
-        <property role="TrG5h" value="org.modelix.mps.rest.model.acess.plugin" />
+        <property role="TrG5h" value="org.modelix.mps.json.bulk.model.access.plugin" />
         <property role="3LESm3" value="3257c0a0-131a-49aa-b7eb-4ec72ed06b33" />
         <node concept="55IIr" id="6KKKEIn3ulB" role="3LF7KH">
           <node concept="2Ry0Ak" id="6KKKEIn3ulC" role="iGT6I">
             <property role="2Ry0Am" value="solutions" />
             <node concept="2Ry0Ak" id="1oqSG6gRUdQ" role="2Ry0An">
-              <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
-              <node concept="2Ry0Ak" id="1oqSG6gRUdV" role="2Ry0An">
-                <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin.msd" />
+              <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
+              <node concept="2Ry0Ak" id="1bAK6cLh$kZ" role="2Ry0An">
+                <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin.msd" />
               </node>
             </node>
           </node>
@@ -229,7 +229,7 @@
               <node concept="2Ry0Ak" id="1oqSG6gRUeJ" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
                 <node concept="2Ry0Ak" id="1oqSG6gRUeK" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
                   <node concept="2Ry0Ak" id="1oqSG6gRUeL" role="2Ry0An">
                     <property role="2Ry0Am" value="models" />
                   </node>
@@ -246,16 +246,16 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
           </node>
         </node>
-        <node concept="1SiIV0" id="7XcypZKMJsP" role="3bR37C">
-          <node concept="1BurEX" id="7XcypZKMJsQ" role="1SiIV1">
-            <node concept="55IIr" id="7XcypZKMJsK" role="1BurEY">
-              <node concept="2Ry0Ak" id="7XcypZKMJsL" role="iGT6I">
+        <node concept="1SiIV0" id="1bAK6cLh$l5" role="3bR37C">
+          <node concept="1BurEX" id="1bAK6cLh$l6" role="1SiIV1">
+            <node concept="55IIr" id="1bAK6cLh$l0" role="1BurEY">
+              <node concept="2Ry0Ak" id="1bAK6cLh$l1" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7XcypZKMJsM" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
-                  <node concept="2Ry0Ak" id="7XcypZKMJsN" role="2Ry0An">
+                <node concept="2Ry0Ak" id="1bAK6cLh$l2" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
+                  <node concept="2Ry0Ak" id="1bAK6cLh$l3" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7XcypZKMJsO" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="1bAK6cLh$l4" role="2Ry0An">
                       <property role="2Ry0Am" value="annotations.jar" />
                     </node>
                   </node>
@@ -264,16 +264,16 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7XcypZKMJsW" role="3bR37C">
-          <node concept="1BurEX" id="7XcypZKMJsX" role="1SiIV1">
-            <node concept="55IIr" id="7XcypZKMJsR" role="1BurEY">
-              <node concept="2Ry0Ak" id="7XcypZKMJsS" role="iGT6I">
+        <node concept="1SiIV0" id="1bAK6cLh$lc" role="3bR37C">
+          <node concept="1BurEX" id="1bAK6cLh$ld" role="1SiIV1">
+            <node concept="55IIr" id="1bAK6cLh$l7" role="1BurEY">
+              <node concept="2Ry0Ak" id="1bAK6cLh$l8" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7XcypZKMJsT" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
-                  <node concept="2Ry0Ak" id="7XcypZKMJsU" role="2Ry0An">
+                <node concept="2Ry0Ak" id="1bAK6cLh$l9" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
+                  <node concept="2Ry0Ak" id="1bAK6cLh$la" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7XcypZKMJsV" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="1bAK6cLh$lb" role="2Ry0An">
                       <property role="2Ry0Am" value="kotlin-stdlib-common.jar" />
                     </node>
                   </node>
@@ -282,16 +282,16 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7XcypZKMJt3" role="3bR37C">
-          <node concept="1BurEX" id="7XcypZKMJt4" role="1SiIV1">
-            <node concept="55IIr" id="7XcypZKMJsY" role="1BurEY">
-              <node concept="2Ry0Ak" id="7XcypZKMJsZ" role="iGT6I">
+        <node concept="1SiIV0" id="1bAK6cLh$lj" role="3bR37C">
+          <node concept="1BurEX" id="1bAK6cLh$lk" role="1SiIV1">
+            <node concept="55IIr" id="1bAK6cLh$le" role="1BurEY">
+              <node concept="2Ry0Ak" id="1bAK6cLh$lf" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7XcypZKMJt0" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
-                  <node concept="2Ry0Ak" id="7XcypZKMJt1" role="2Ry0An">
+                <node concept="2Ry0Ak" id="1bAK6cLh$lg" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
+                  <node concept="2Ry0Ak" id="1bAK6cLh$lh" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7XcypZKMJt2" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="1bAK6cLh$li" role="2Ry0An">
                       <property role="2Ry0Am" value="kotlin-stdlib-jdk7.jar" />
                     </node>
                   </node>
@@ -300,16 +300,16 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7XcypZKMJta" role="3bR37C">
-          <node concept="1BurEX" id="7XcypZKMJtb" role="1SiIV1">
-            <node concept="55IIr" id="7XcypZKMJt5" role="1BurEY">
-              <node concept="2Ry0Ak" id="7XcypZKMJt6" role="iGT6I">
+        <node concept="1SiIV0" id="1bAK6cLh$lq" role="3bR37C">
+          <node concept="1BurEX" id="1bAK6cLh$lr" role="1SiIV1">
+            <node concept="55IIr" id="1bAK6cLh$ll" role="1BurEY">
+              <node concept="2Ry0Ak" id="1bAK6cLh$lm" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7XcypZKMJt7" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
-                  <node concept="2Ry0Ak" id="7XcypZKMJt8" role="2Ry0An">
+                <node concept="2Ry0Ak" id="1bAK6cLh$ln" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
+                  <node concept="2Ry0Ak" id="1bAK6cLh$lo" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7XcypZKMJt9" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="1bAK6cLh$lp" role="2Ry0An">
                       <property role="2Ry0Am" value="kotlin-stdlib-jdk8.jar" />
                     </node>
                   </node>
@@ -318,16 +318,16 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7XcypZKMJth" role="3bR37C">
-          <node concept="1BurEX" id="7XcypZKMJti" role="1SiIV1">
-            <node concept="55IIr" id="7XcypZKMJtc" role="1BurEY">
-              <node concept="2Ry0Ak" id="7XcypZKMJtd" role="iGT6I">
+        <node concept="1SiIV0" id="1bAK6cLh$lx" role="3bR37C">
+          <node concept="1BurEX" id="1bAK6cLh$ly" role="1SiIV1">
+            <node concept="55IIr" id="1bAK6cLh$ls" role="1BurEY">
+              <node concept="2Ry0Ak" id="1bAK6cLh$lt" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7XcypZKMJte" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
-                  <node concept="2Ry0Ak" id="7XcypZKMJtf" role="2Ry0An">
+                <node concept="2Ry0Ak" id="1bAK6cLh$lu" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
+                  <node concept="2Ry0Ak" id="1bAK6cLh$lv" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7XcypZKMJtg" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="1bAK6cLh$lw" role="2Ry0An">
                       <property role="2Ry0Am" value="kotlin-stdlib.jar" />
                     </node>
                   </node>
@@ -336,16 +336,16 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7XcypZKMJto" role="3bR37C">
-          <node concept="1BurEX" id="7XcypZKMJtp" role="1SiIV1">
-            <node concept="55IIr" id="7XcypZKMJtj" role="1BurEY">
-              <node concept="2Ry0Ak" id="7XcypZKMJtk" role="iGT6I">
+        <node concept="1SiIV0" id="1bAK6cLh$lC" role="3bR37C">
+          <node concept="1BurEX" id="1bAK6cLh$lD" role="1SiIV1">
+            <node concept="55IIr" id="1bAK6cLh$lz" role="1BurEY">
+              <node concept="2Ry0Ak" id="1bAK6cLh$l$" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7XcypZKMJtl" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
-                  <node concept="2Ry0Ak" id="7XcypZKMJtm" role="2Ry0An">
+                <node concept="2Ry0Ak" id="1bAK6cLh$l_" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
+                  <node concept="2Ry0Ak" id="1bAK6cLh$lA" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7XcypZKMJtn" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="1bAK6cLh$lB" role="2Ry0An">
                       <property role="2Ry0Am" value="kotlinx-serialization-core-jvm.jar" />
                     </node>
                   </node>
@@ -354,16 +354,16 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7XcypZKMJtv" role="3bR37C">
-          <node concept="1BurEX" id="7XcypZKMJtw" role="1SiIV1">
-            <node concept="55IIr" id="7XcypZKMJtq" role="1BurEY">
-              <node concept="2Ry0Ak" id="7XcypZKMJtr" role="iGT6I">
+        <node concept="1SiIV0" id="1bAK6cLh$lJ" role="3bR37C">
+          <node concept="1BurEX" id="1bAK6cLh$lK" role="1SiIV1">
+            <node concept="55IIr" id="1bAK6cLh$lE" role="1BurEY">
+              <node concept="2Ry0Ak" id="1bAK6cLh$lF" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7XcypZKMJts" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
-                  <node concept="2Ry0Ak" id="7XcypZKMJtt" role="2Ry0An">
+                <node concept="2Ry0Ak" id="1bAK6cLh$lG" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
+                  <node concept="2Ry0Ak" id="1bAK6cLh$lH" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7XcypZKMJtu" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="1bAK6cLh$lI" role="2Ry0An">
                       <property role="2Ry0Am" value="kotlinx-serialization-json-jvm.jar" />
                     </node>
                   </node>
@@ -372,16 +372,16 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7XcypZKMJtA" role="3bR37C">
-          <node concept="1BurEX" id="7XcypZKMJtB" role="1SiIV1">
-            <node concept="55IIr" id="7XcypZKMJtx" role="1BurEY">
-              <node concept="2Ry0Ak" id="7XcypZKMJty" role="iGT6I">
+        <node concept="1SiIV0" id="1bAK6cLh$lQ" role="3bR37C">
+          <node concept="1BurEX" id="1bAK6cLh$lR" role="1SiIV1">
+            <node concept="55IIr" id="1bAK6cLh$lL" role="1BurEY">
+              <node concept="2Ry0Ak" id="1bAK6cLh$lM" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7XcypZKMJtz" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
-                  <node concept="2Ry0Ak" id="7XcypZKMJt$" role="2Ry0An">
+                <node concept="2Ry0Ak" id="1bAK6cLh$lN" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
+                  <node concept="2Ry0Ak" id="1bAK6cLh$lO" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7XcypZKMJt_" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="1bAK6cLh$lP" role="2Ry0An">
                       <property role="2Ry0Am" value="model-api-jvm.jar" />
                     </node>
                   </node>
@@ -390,16 +390,16 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7XcypZKMJtH" role="3bR37C">
-          <node concept="1BurEX" id="7XcypZKMJtI" role="1SiIV1">
-            <node concept="55IIr" id="7XcypZKMJtC" role="1BurEY">
-              <node concept="2Ry0Ak" id="7XcypZKMJtD" role="iGT6I">
+        <node concept="1SiIV0" id="1bAK6cLh$lX" role="3bR37C">
+          <node concept="1BurEX" id="1bAK6cLh$lY" role="1SiIV1">
+            <node concept="55IIr" id="1bAK6cLh$lS" role="1BurEY">
+              <node concept="2Ry0Ak" id="1bAK6cLh$lT" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7XcypZKMJtE" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.modelix.mps.rest.model.acess.plugin" />
-                  <node concept="2Ry0Ak" id="7XcypZKMJtF" role="2Ry0An">
+                <node concept="2Ry0Ak" id="1bAK6cLh$lU" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.mps.json.bulk.model.access.plugin" />
+                  <node concept="2Ry0Ak" id="1bAK6cLh$lV" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7XcypZKMJtG" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="1bAK6cLh$lW" role="2Ry0An">
                       <property role="2Ry0Am" value="model-server.jar" />
                     </node>
                   </node>

--- a/mps-plugin/solutions/org.modelix.mps.json.bulk.model.access.plugin.build/org.modelix.mps.json.bulk.model.access.plugin.build.msd
+++ b/mps-plugin/solutions/org.modelix.mps.json.bulk.model.access.plugin.build/org.modelix.mps.json.bulk.model.access.plugin.build.msd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="org.modelix.mps.rest.model.access.plugin.build" uuid="449011d8-ce64-47d2-9dc9-87b407588952" moduleVersion="0" compileInMPS="true">
+<solution name="org.modelix.mps.json.bulk.model.access.plugin.build" uuid="449011d8-ce64-47d2-9dc9-87b407588952" moduleVersion="0" compileInMPS="true">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
@@ -21,7 +21,7 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
-    <module reference="449011d8-ce64-47d2-9dc9-87b407588952(org.modelix.mps.rest.model.access.plugin.build)" version="0" />
+    <module reference="449011d8-ce64-47d2-9dc9-87b407588952(org.modelix.mps.json.bulk.model.access.plugin.build)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/mps-plugin/solutions/org.modelix.mps.json.bulk.model.access.plugin/models/org.modelix.mps.json.bulk.model.access.plugin.plugin.mps
+++ b/mps-plugin/solutions/org.modelix.mps.json.bulk.model.access.plugin/models/org.modelix.mps.json.bulk.model.access.plugin.plugin.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:b61e466d-2b62-484c-a3b0-37acdf6898f0(org.modelix.mps.rest.model.acess.plugin.plugin)">
+<model ref="r:b61e466d-2b62-484c-a3b0-37acdf6898f0(org.modelix.mps.json.bulk.model.access.plugin.plugin)">
   <persistence version="9" />
   <languages>
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />

--- a/mps-plugin/solutions/org.modelix.mps.json.bulk.model.access.plugin/org.modelix.mps.json.bulk.model.access.plugin.msd
+++ b/mps-plugin/solutions/org.modelix.mps.json.bulk.model.access.plugin/org.modelix.mps.json.bulk.model.access.plugin.msd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="org.modelix.mps.rest.model.acess.plugin" uuid="3257c0a0-131a-49aa-b7eb-4ec72ed06b33" moduleVersion="0" pluginKind="PLUGIN_OTHER" compileInMPS="true">
+<solution name="org.modelix.mps.json.bulk.model.access.plugin" uuid="3257c0a0-131a-49aa-b7eb-4ec72ed06b33" moduleVersion="0" pluginKind="PLUGIN_OTHER" compileInMPS="true">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
@@ -64,8 +64,9 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
     <module reference="306183fb-952a-4095-9ca0-a4b846e2036e(org.modelix.modelcheck.mps.plugin)" version="0" />
-    <module reference="3257c0a0-131a-49aa-b7eb-4ec72ed06b33(org.modelix.mps.rest.model.acess.plugin)" version="0" />
+    <module reference="3257c0a0-131a-49aa-b7eb-4ec72ed06b33(org.modelix.mps.json.bulk.model.access.plugin)" version="0" />
   </dependencyVersions>
 </solution>
 


### PR DESCRIPTION
The plugin was forgotten when renaming to `json-bulk-access`. This PR aims to fix this issue.